### PR TITLE
[Niyas] Docs Deletion Patch

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,13 +61,7 @@ const config = {
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
-        docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
-        },
+        docs: false,
         blog: {
           showReadingTime: true
         },


### PR DESCRIPTION
- Docs is now entirely removed. `npm run build` will work this time, since docs is disabled.